### PR TITLE
Added variables for encoding handling

### DIFF
--- a/pyLSV2/client.py
+++ b/pyLSV2/client.py
@@ -51,7 +51,7 @@ class LSV2:
     """Implementation of the LSV2 protocol used to communicate with certain CNC controls"""
 
     def __init__(
-        self, hostname, port=0, timeout=15.0, safe_mode=True, locale_path=None
+        self, hostname, port=0, timeout=15.0, safe_mode=True, locale_path=None, enc_errors='ignore', enc_encoding='utf-8'
     ):
         """init object variables and create socket"""
         logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -87,6 +87,9 @@ class LSV2:
         self._secure_file_send = False
         self._control_type = ControlType.UNKNOWN
         self._last_error_code = None
+
+        self._enc_errors = enc_errors
+        self._enc_encoding = enc_encoding
 
         if locale_path is None:
             self._locale_path = os.path.join(os.path.dirname(__file__), "locales")
@@ -514,13 +517,13 @@ class LSV2:
             stack_info["Main_PGM"] = (
                 result[4:]
                 .split(b"\x00")[0]
-                .decode()
+                .decode(encoding = self._enc_encoding, errors = self._enc_errors)
                 .strip("\x00")  # .replace("\\", "/")
             )
             stack_info["Current_PGM"] = (
                 result[4:]
                 .split(b"\x00")[1]
-                .decode()
+                .decode(encoding = self._enc_encoding, errors = self._enc_errors)
                 .strip("\x00")  # .replace("\\", "/")
             )
             logging.debug(


### PR DESCRIPTION
I experienced an issue when polling the program status using `get_program_stack()`, which would throw a 
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position xy: invalid continuation byte`

Reason in my case is that the machine program running has a german "Umlaut" in its file name (e.g., TNC:\\X\\Y\\Z\xänderung.h', which does not seem to be encoded correctly. Since the error is thrown within the pyLSV2-lib, I can't just ignore the error and continue, since the rest of the queried information from `get_program_stack()` is then gone, too. 

To solve this issue, one can either specify the desired encoding in the `decode()` method, or one sets the error handling of the same method to either ignore undecodable bytes or replacing them. It seems both approaches can be useful for the user, so I suggest to provide some parameters for the user to set both options.

While the library decodes many values from the machine, it seems, that only in `get_program_stack()` values are transmitted which originate from the user instead of the machine itself. Thus, I would expect that we do not see these issues in any other part of the code. Yet, I might be wrong here and having these options would be a good idea at other places as well. 

Changes made in `client.py`:
+ Introduced variable in `__init__` allowing a user to set the strategy for handling encoding errors. Default value corresponds to default value of encoding in `decode()` method (encoding = "utf-8")
+ Introduced variable in `__init__` allowing a user to set the desired encoding to be used. Default value corresponds to default value of `errors` in decode() method (errors="strict")
+ Added both options to the decode-methods used in `get_program_stack()`
